### PR TITLE
Add mjirv/dbt-datamocktool to hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -144,5 +144,8 @@
     "beautypie": [
         "dbt-google-analytics-360",
         "dbt-zendesk-support"
+    ],
+    "mjirv": [
+        "dbt-datamocktool"
     ]
 }


### PR DESCRIPTION
datamocktool is a package for writing unit tests natively in dbt.

See https://github.com/mjirv/dbt-datamocktool for more information on usage.