### PR TITLE
Add dbt-snowplow-utils repo to hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -147,5 +147,8 @@
     ],
     "mjirv": [
         "dbt-datamocktool"
+    ],
+    "snowplow": [
+        "dbt-snowplow-utils"
     ]
 }


### PR DESCRIPTION
Adding the snowplow-utils package to dbt hub. This package is to be used in conjunction with the snowplow-web package (to be released soon).