### PR TITLE
Hotfix - Replace Nones with empty iterables for package version specs

### DIFF
--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -16,13 +16,15 @@ def has_dbt_project_yml(directory):
 
 def parse_pkg_name(repo_dir):
     with open(repo_dir / Path('dbt_project.yml'), 'r') as stream:
-        return yaml.safe_load(stream)['name']
+        name = yaml.safe_load(stream)['name']
+        return name if name else ''
 
 
 def parse_pkgs(repo_dir):
     if os.path.exists(repo_dir / 'packages.yml'):
         with open(repo_dir / Path('packages.yml'), 'r') as stream:
-            return yaml.safe_load(stream)['packages']
+            pkgs = yaml.safe_load(stream)['packages']
+            return pkgs if pkgs else []
 
 
 def cut_version_branch(org_name, repo, separate_commits_by_pkg):

--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -25,6 +25,8 @@ def parse_pkgs(repo_dir):
         with open(repo_dir / Path('packages.yml'), 'r') as stream:
             pkgs = yaml.safe_load(stream)['packages']
             return pkgs if pkgs else []
+    else:
+        return []
 
 
 def cut_version_branch(org_name, repo, separate_commits_by_pkg):


### PR DESCRIPTION
So, this [spec](https://github.com/dbt-labs/hub.getdbt.com/commit/ff1a01625ee55efee0370e26eb21b57b8dd4c8b5) for `dbtplyr` has a bug.  

The `null` on `packages:` should be a `[]` 'cus iterables. But, the `yaml.parse` function in python wants to return a `None` instead of an empty list. Then again, somewhere in hub (where I know not) wants an iterable, so we'll give it one.

