### PR TITLE
remove packages which are leading to dead pages

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -145,10 +145,6 @@
     "re-data": [
         "dbt-re-data"
     ],
-    "beautypie": [
-        "dbt-google-analytics-360",
-        "dbt-zendesk-support"
-    ],
     "mjirv": [
         "dbt-datamocktool"
     ],


### PR DESCRIPTION
Currently the two packages listed under [Beautypie](https://github.com/beautypie)
- [google_analytics_360](https://github.com/beautypie/dbt-google-analytics-360/tree/0.1.0/)
- [zendesk support](https://hub.getdbt.com/beautypie/zendesk_support/latest/) both lead to dead pages.

We might want to consider reaching out to them to see if these are coming back / what the status is but in the meantime we should probably remove them from the site.