### PR TITLE
Hotfix: filter existing tags of packages to allow for easy semantic version sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 env/
 git-tmp/
+*.swp
+__pycache__/
 config.json
 hub.current.json

--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ Hubcap is the script that generates the pages of the dbt package registry site, 
 
 Each hour, `hubcap.py` runs, and checks whether there are new releases for any of the repositories listed in [hub.json](/hub.json). If a new release has been created, or a new package has been added to the list, a Pull Request is opened against the [hub.getdbt.com repository](https://github.com/fishtown-analytics/hub.getdbt.com) to update the the registry site to reflect this. PRs are approved by a member of the Fishtown Analytics team, typically within one business day.
 
+### Caveats and Gotchas
+Assorted constraints:
+* project must be hosted on GitHub
+* your project _must_ have a [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml) with a `name:` tag in the yaml
+* if used by your project, a `packages.yml` must live at the root level of your project repository
+* only release names that use [semantic versioning](https://semver.org/) will be picked up by hubcap — both `0.1.0` and `v0.1.0` will be picked up, but `first-release` will not.
+
 ### Adding your package to hubcap
 Currently, only packages hosted on a GitHub repo are supported.
 
 To add your package, open a PR that adds your repository to [hub.json](hub.json).
-
-Note that only release names that use [semantic versioning](https://semver.org/) will be picked up by hubcap — both `0.1.0` and `v0.1.0` will be picked up, but `first-release` will not.

--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -6,8 +6,9 @@ import yaml
 
 from pathlib import Path
 
+import version
+
 from setup import *
-from version import *
 
 
 def has_dbt_project_yml(directory):
@@ -72,7 +73,7 @@ def make_index(org_name, repo, package_name, existing, tags, git_path):
 
     # attempt to grab the latest release version of a project
 
-    version_numbers = [tag[1:] if tag.startswith('v') else tag for tag in tags]
+    version_numbers = [version.strip_v_from_version(tag) for tag in tags]
     version_numbers.sort(key=lambda s: list(map(int, s.split('.'))))
     latest_version = version_numbers[-1]
 

--- a/hubcap/version.py
+++ b/hubcap/version.py
@@ -23,11 +23,15 @@ def strip_v_from_version(tag):
 
 
 def get_existing_tags(pkg_index_records):
-    return { pkg_index_record['version'] for pkg_index_record in pkg_index_records }
+    '''in: the version index of a package checked into hub
+    out: only semver compliant tags'''
+    existing_hub_tags = { pkg_index_record['version'] for pkg_index_record in pkg_index_records }
+    return set(filter(is_valid_semver_tag, existing_hub_tags))
 
 
 def get_new_tags(pkg_index_records):
-    '''designed to be run inside a package repo'''
+    '''designed to be run inside a package repo
+    will not pick up tags other than those which are semver compliant'''
 
     run_cmd('git fetch --quiet --tags')
     all_remote_tags = run_cmd('git tag --list', quiet=True).split('\n')


### PR DESCRIPTION
Do not consider malformed version tags of packages already present in hub.getdbt.com when building specs.

## Bug: 
![image](https://user-images.githubusercontent.com/67295367/133330023-044e769c-7fe9-4b15-8db2-1a34baf06866.png)

dbt datamock tool had package versions checked in which are not classically semver compliant, so now I'm ignoring these in fetches for 'existing tags' on a package name.

## Evidence of fix:
![image](https://user-images.githubusercontent.com/67295367/133330065-bc7e21a5-ebc9-45de-9eb4-2408407a7a03.png)

With the script able to move, a small backlog of packages will be pushed once this script is rerun on staging or in production. Those package versions include the two Fivetran packages mentioned in [hub.getdbt.com issue #865](https://github.com/dbt-labs/hub.getdbt.com/issues/865).

## Addendum
I also added a lil' bit of notation to chip away at #67 .
