### PR TITLE
Address the coming changes to Fivetran's default branches and package dependency versions

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -1,18 +1,41 @@
 #!/bin/bash
 
 # ==
+# == Parse args
+# ==
+
+POSITIONAL=()
+while [ "$#" != '0' ]; do
+  case "$1" in
+    # useful for wanting to save git-tmp and observe commits/build artifacts
+    -n|--no-cleanup)
+      CLEANUP='no'
+      shift
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${POSITIONAL[@]}"
+
+# ==
 # == Setup
 # ==
 
+# export to expose to python script later on
 export RUN_DIR="$(pwd)"
 export GIT_TMP="$RUN_DIR/git-tmp"
 
 exit_routine() {
   local -r exit_status="${1}"
 
+  if [ "${CLEANUP:-yes}" = 'yes' ]; then
     if [ -d "${GIT_TMP}" ]; then
         rm -rf "${GIT_TMP}"
     fi
+  fi
 
   exit "${exit_status}"
 }
@@ -35,10 +58,12 @@ if [ "$ENV" = 'prod' ] || [ "$ENV" = 'test' ]; then
     git config --global user.name 'dbt-hubcap'
 fi
 
+# hubcap expects a fresh git-tmp, so deletion of git-tmp is forced before script is allowed to run in full
 if ! [ -d "${GIT_TMP}" ]; then
     mkdir "${GIT_TMP}"
 else
-    >&2 printf "Error: ${GIT_TMP} already exists. Deleting and exiting."
+    >&2 printf "Error: ${GIT_TMP} already exists. Deleting and exiting.\n"
+    unset CLEANUP
     exit 1
 fi
 

--- a/cron.sh
+++ b/cron.sh
@@ -31,15 +31,9 @@ set -o pipefail
 # specified in Heroku's config variables
 export ENV="${ENV-development}"
 if [ "$ENV" = 'prod' ] || [ "$ENV" = 'test' ]; then
-    email='drew@fishtownanalytics.com'
-    user_name='dbt-hubcap'
-else
-    email='test@notarealuser.com'
-    user_name='dbt-hubcap-staging'
+    git config --global user.email 'drew@fishtownanalytics.com'  # TODO: make this a dedicated CI user
+    git config --global user.name 'dbt-hubcap'
 fi
-
-git config --global user.email "${email}"
-git config --global user.name "${user_name}"
 
 if ! [ -d "${GIT_TMP}" ]; then
     mkdir "${GIT_TMP}"

--- a/exclusions.json
+++ b/exclusions.json
@@ -21,5 +21,9 @@
    "beautypie":[
       "dbt-google-analytics-360",
       "dbt-zendesk-support"
+   ],
+   "fivetran":[
+      "dbt_zuora",
+      "dbt_zuora_source"
    ]
 }

--- a/hubcap/cmd.py
+++ b/hubcap/cmd.py
@@ -1,8 +1,12 @@
 
 import logging
+import os
 import subprocess
 import sys
 
+from git import cmd
+from git import Repo
+from pathlib import Path
 
 def run_cmd(cmd, quiet=False):
     proc = subprocess.run(args=cmd.split(), capture_output=True)
@@ -18,3 +22,25 @@ def run_cmd(cmd, quiet=False):
     proc.check_returncode()
 
     return output
+
+
+def repo_default_branch(repo):
+    prev_dir = os.getcwd()
+    os.chdir(repo.working_dir)
+
+    remote_info = cmd.Git().remote('show', 'origin')
+    default_branch_name = remote_info.split('\n')[3].split()[-1]
+
+    os.chdir(prev_dir)
+    return default_branch_name
+
+
+def clone_repo(remote, path):
+    '''clone down a github repo to a path and a reference to that directory'''
+    logging.info(f'cloning {remote} to {path}')
+    repo = Repo.clone_from(remote, path)
+
+    main_branch = repo_default_branch(repo)
+    repo.git.checkout(main_branch)
+    repo.remotes.origin.pull()
+    return path

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -5,7 +5,10 @@ import requests
 
 from pathlib import Path
 
-from setup import *
+import setup
+import version
+import package
+
 from cmd import *
 
 # ==
@@ -13,113 +16,37 @@ from cmd import *
 # ==
 
 logging.info('preparing script state')
-config = build_config()
+config = setup.build_config()
 
 ONE_BRANCH_PER_REPO = config['one_branch_per_repo']
 PUSH_BRANCHES = config['push_branches']
-REMOTE = config['remote']
+REMOTE = 'https://github.com/dbt-labs/hub.getdbt.com.git'
 TMP_DIR = os.environ['GIT_TMP']
-TRACKED_REPOS = config['tracked_repos']
+TRACKED_REPOS = setup.load_tracked_repo_records()
 
-# ==
-# == Pull down the newest version of the hub repo
-# ==
+# pull down hub to assess current state and have ready for future commits
+hub_dir_path = clone_repo(REMOTE, TMP_DIR / Path('hub'))
 
-hub_dir = TMP_DIR / Path('hub')
-logging.info(f'cloning hub site repo to {hub_dir}')
-run_cmd(f'git clone --quiet {REMOTE} {hub_dir}')
-os.chdir(hub_dir)
-run_cmd('git checkout master')
-run_cmd('git pull origin master')
+# create a record in memory of what versions are already committed into the hub
+existing_pkg_version_index = setup.build_pkg_version_index(hub_dir_path)
 
-index = build_version_index()
-new_branches = {}
+# =
+# = Determine new package versions
+# =
 
-# ==
-# == Cut a branch for each new version of each package
-# ==
+logging.info('cloning package repos')
+package.clone_package_repos(TRACKED_REPOS, TMP_DIR)
 
-from version import *
-from package import *
+logging.info('collecting the new version tags for packages checked into hub')
+pkgs_with_updates = package.get_pkgs_with_updates(TRACKED_REPOS, existing_pkg_version_index, TMP_DIR)
+
+# =
+# = Create new specs and commit them to separate branches in hub
+# =
 
 logging.info('preparing branches for packages with versions to be added')
-for org_name, repos in TRACKED_REPOS.items():
-    for repo in repos:
-        os.chdir(TMP_DIR)
-        current_repo_path = TMP_DIR / Path(repo)
-
-        logging.info(f'cloning package {repo} maintained by {org_name} to {current_repo_path}')
-        clone_url = f'https://github.com/{org_name}/{repo}.git'
-        run_cmd(f'git clone --quiet {clone_url} {repo}')
-
-        # skip repo if no dbt project yaml or no new tags
-        if not has_dbt_project_yml(current_repo_path):
-            logging.warning(f'{repo} has no dbt_project.yml. Skipping...')
-            continue
-
-        package_name = parse_pkg_name(current_repo_path)
-        packages = parse_pkgs(current_repo_path)
-
-        os.chdir(current_repo_path)
-        logging.info(f'collecting tags for {package_name}')
-        new_tags = get_new_tags(index[org_name][package_name])
-
-        if new_tags:
-            logging.info(f'new tags:    {sorted(new_tags)}')
-        else:
-            logging.warning(f'no new tags for {repo}. Skipping...')
-            continue
-
-        # =
-        # = Create new specs and commit them to separate branches in hub
-        # =
-
-        os.chdir(hub_dir) # will not change until tag loop
-        repo_dir = hub_dir / 'data' / 'packages' / org_name / package_name / 'versions'
-        Path.mkdir(repo_dir, parents=True, exist_ok=True)
-
-        # in hubcap, on a branch for each package, commit the package version specs for any new tags
-        branch_name = cut_version_branch(org_name, repo, ONE_BRANCH_PER_REPO)
-        new_branches[branch_name] = {"org": org_name, "repo": package_name}
-
-        # create an updated version of the repo's index.json
-        index_file_path = hub_dir / 'data' / 'packages' / org_name / package_name / 'index.json'
-
-        new_index_entry = make_index(
-            org_name,
-            repo,
-            package_name,
-            fetch_index_file_contents(index_file_path),
-            new_tags | get_existing_tags(index[org_name][package_name]),
-            current_repo_path
-        )
-
-        with open(index_file_path, 'w') as f:
-            logging.info(f'writing index.json to {index_file_path}')
-            f.write(str(json.dumps(new_index_entry, indent=4)))
-
-        # create a version spec for each tag
-        for tag in new_tags:
-            package_spec = make_spec(org_name, repo, package_name, packages, tag, current_repo_path)
-
-            version_path = repo_dir / Path(f'{tag}.json')
-
-            with open(version_path, 'w') as f:
-                logging.info(f'writing spec to {version_path}')
-                f.write(str(json.dumps(package_spec, indent=4)))
-
-            # checkout tag within current package repo and create JSON spec
-            os.chdir(repo_dir)
-            msg = f'hubcap: Adding tag {tag} for {org_name}/{repo}'
-            logging.info(msg)
-            run_cmd('git add -A')
-            subprocess.run(args=['git', 'commit', '-am', f'{msg}'], capture_output=True)
-            new_branches[branch_name]['new'] = True
-
-        # good house keeping
-        os.chdir(hub_dir)
-        run_cmd('git checkout master')
-
+# this wants to take place inside the git-tmp/hub repo
+new_branches = package.commit_version_updates_to_hub(pkgs_with_updates, hub_dir_path)
 
 # =
 # = push new branches, if there are any

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -56,7 +56,7 @@ from release_carrier import *
 
 logging.info("Push branches? {} - {}".format(PUSH_BRANCHES, list(new_branches.keys())))
 if new_branches:
-    os.chdir(hub_dir)
+    os.chdir(hub_dir_path)
     run_cmd(f'git remote add hub {REMOTE}')
 
     open_prs = get_open_prs(config)
@@ -69,11 +69,11 @@ if new_branches:
             logging.info("PR is already open for {}/{}. Skipping.".format(info['org'], info['repo']))
             continue
 
-        os.chdir(hub_dir)
+        os.chdir(hub_dir_path)
         run_cmd(f'git checkout {branch}')
         run_cmd(f'git fetch hub')
 
-        if PUSH_BRANCHES and (os.environ['ENV'] == 'test' or os.environ['ENV'] == 'prod'):
+        if PUSH_BRANCHES and os.environ['ENV'] == 'prod':
             logging.info("pushing and PRing for {}/{}".format(info['org'], info['repo']))
             run_cmd(f'git push hub {branch}')
             make_pr(info['org'], info['repo'], branch, config)

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -46,7 +46,7 @@ pkgs_with_updates = package.get_pkgs_with_updates(TRACKED_REPOS, existing_pkg_ve
 
 logging.info('preparing branches for packages with versions to be added')
 # this wants to take place inside the git-tmp/hub repo
-new_branches = package.commit_version_updates_to_hub(pkgs_with_updates, hub_dir_path)
+new_branches = package.commit_version_updates_to_hub(pkgs_with_updates, hub_dir_path, ONE_BRANCH_PER_REPO)
 
 # =
 # = push new branches, if there are any

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -20,7 +20,7 @@ config = setup.build_config()
 
 ONE_BRANCH_PER_REPO = config['one_branch_per_repo']
 PUSH_BRANCHES = config['push_branches']
-REMOTE = 'https://github.com/dbt-labs/hub.getdbt.com.git'
+REMOTE = config['remote']
 TMP_DIR = os.environ['GIT_TMP']
 TRACKED_REPOS = setup.load_tracked_repo_records()
 

--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -209,7 +209,6 @@ def commit_version_updates_to_hub(new_pkg_version_index, hub_dir_path, one_branc
             for tag in new_tags:
                 # go to repo dir to checkout tag and tag-commit specific package list
                 os.chdir(repo_path)
-                run_cmd(f'git tag')
                 run_cmd(f'git checkout tags/{tag}')
                 packages = parse_pkgs(Path(os.getcwd()))
 

--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -4,6 +4,8 @@ import requests
 import subprocess
 import yaml
 
+from git import cmd
+from git import Repo
 from pathlib import Path
 
 import version
@@ -15,19 +17,60 @@ def has_dbt_project_yml(directory):
     return os.path.exists(directory / Path('dbt_project.yml'))
 
 
-def parse_pkg_name(repo_dir):
-    with open(repo_dir / Path('dbt_project.yml'), 'r') as stream:
-        name = yaml.safe_load(stream)['name']
-        return name if name else ''
+def clone_package_repos(repo_index, path):
+    '''clone all package repos listed in index to path'''
+    for org_name, repos in repo_index.items():
+        for repo in repos:
+            current_repo_path = path / Path(repo)
+
+            logging.info(f'cloning package {repo} maintained by {org_name} to {current_repo_path}')
+            clone_repo(f'https://github.com/{org_name}/{repo}.git', current_repo_path)
+
+            # debugging for time
+            return
 
 
-def parse_pkgs(repo_dir):
-    if os.path.exists(repo_dir / 'packages.yml'):
-        with open(repo_dir / Path('packages.yml'), 'r') as stream:
-            pkgs = yaml.safe_load(stream)['packages']
-            return pkgs if pkgs else []
-    else:
-        return []
+def get_pkgs_with_updates(repo_index, version_index, path):
+    '''obtain a sublist of the existing repo_index: all those packages with updates'''
+
+    def parse_pkg_name(repo_dir):
+        with open(repo_dir / Path('dbt_project.yml'), 'r') as stream:
+            name = yaml.safe_load(stream)['name']
+            return name if name else ''
+
+    def parse_pkgs(repo_dir):
+        if os.path.exists(repo_dir / 'packages.yml'):
+            with open(repo_dir / Path('packages.yml'), 'r') as stream:
+                pkgs = yaml.safe_load(stream)['packages']
+                return pkgs if pkgs else []
+        else:
+            return []
+
+    res = {}
+    for org_name, repos in repo_index.items():
+        for repo in repos:
+            current_repo_path = path / Path(repo)
+
+            if has_dbt_project_yml(current_repo_path):
+                package_name = parse_pkg_name(current_repo_path)
+                packages = parse_pkgs(current_repo_path)
+                logging.info(f'collecting tags for {package_name}')
+
+                existing_tags = version.get_existing_tags(version_index[org_name][package_name])
+                logging.info(f'pkg hub tags:    {sorted(existing_tags)}')
+
+                valid_remote_tags = version.get_valid_remote_tags(Repo(current_repo_path))
+                logging.info(f'pkg remote tags: {sorted(valid_remote_tags)}')
+
+                new_tags = list(valid_remote_tags - existing_tags) + ['0.7.2'] # TODO remove this
+                if new_tags:
+                    logging.info(f'adding new tags {list(new_tags)} to {package_name} repo')
+                    if org_name not in res:
+                        res[org_name] = {}
+                    res[org_name][repo] = (package_name, current_repo_path, new_tags)
+            else:
+                logging.warning(f'{repo} has no dbt_project.yml. Skipping...')
+    return res
 
 
 def cut_version_branch(org_name, repo, separate_commits_by_pkg):
@@ -132,3 +175,55 @@ def make_spec(org, repo, package_name, packages, version, git_path):
             "sha1": sha1
         }
     }
+
+def commit_version_updates_to_hub(new_pkg_version_index, hub_dir_path):
+    '''input: {org_name: {repo_name:(package_name, [version tags])}}
+    output: {branch_name: hashmap of branch info}
+    N.B. this function will make changes to the hub only
+    '''
+    for org_name, new_repo_tags in new_pkg_version_index.items():
+        for repo, (package_name, current_repo_path, new_tags) in new_repo_tags.items():
+            os.chdir(hub_dir_path)
+            repo_hub_version_dir = hub_dir_path / 'data' / 'packages' / org_name / package_name / 'versions'
+            Path.mkdir(repo_hub_version_dir, parents=True, exist_ok=True)
+
+            # in hub, on a branch for each package, commit the package version specs for any new tags
+            branch_name = cut_version_branch(org_name, repo, ONE_BRANCH_PER_REPO)
+            new_branches[branch_name] = {"org": org_name, "repo": package_name}
+
+            # create an updated version of the repo's index.json
+            index_file_path = hub_dir_path / 'data' / 'packages' / org_name / package_name / 'index.json'
+
+            new_index_entry = make_index(
+                org_name,
+                repo,
+                package_name,
+                package.fetch_index_file_contents(index_file_path),
+                set(new_tags) | version.get_existing_tags(existing_pkg_version_index[org_name][repo]),
+                current_repo_path
+            )
+
+            with open(index_file_path, 'w') as f:
+                logging.info(f'writing index.json to {index_file_path}')
+                f.write(str(json.dumps(new_index_entry, indent=4)))
+
+            # create a version spec for each tag
+            for tag in new_tags:
+                # TODO: patch in the code to get packages from each tag
+                package_spec = make_spec(org_name, repo, package_name, packages, tag, current_repo_path)
+
+                version_path = repo_hub_version_dir / Path(f'{tag}.json')
+
+                with open(version_path, 'w') as f:
+                    logging.info(f'writing spec to {version_path}')
+                    f.write(str(json.dumps(package_spec, indent=4)))
+
+                msg = f'hubcap: Adding tag {tag} for {org_name}/{repo}'
+                logging.info(msg)
+                run_cmd('git add -A')
+                subprocess.run(args=['git', 'commit', '-am', f'{msg}'], capture_output=True)
+                new_branches[branch_name]['new'] = True
+
+            # good house keeping
+            os.chdir(hub_dir_path)
+            run_cmd('git checkout master')

--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -26,26 +26,23 @@ def clone_package_repos(repo_index, path):
             logging.info(f'cloning package {repo} maintained by {org_name} to {current_repo_path}')
             clone_repo(f'https://github.com/{org_name}/{repo}.git', current_repo_path)
 
-            # debugging for time
-            return
+
+def parse_pkg_name(repo_dir):
+    with open(repo_dir / Path('dbt_project.yml'), 'r') as stream:
+        name = yaml.safe_load(stream)['name']
+        return name if name else ''
+
+def parse_pkgs(repo_dir):
+    if os.path.exists(repo_dir / 'packages.yml'):
+            with open(repo_dir / Path('packages.yml'), 'r') as stream:
+                pkgs = yaml.safe_load(stream)['packages']
+                return pkgs if pkgs else []
+    else:
+        return []
 
 
 def get_pkgs_with_updates(repo_index, version_index, path):
     '''obtain a sublist of the existing repo_index: all those packages with updates'''
-
-    def parse_pkg_name(repo_dir):
-        with open(repo_dir / Path('dbt_project.yml'), 'r') as stream:
-            name = yaml.safe_load(stream)['name']
-            return name if name else ''
-
-    def parse_pkgs(repo_dir):
-        if os.path.exists(repo_dir / 'packages.yml'):
-            with open(repo_dir / Path('packages.yml'), 'r') as stream:
-                pkgs = yaml.safe_load(stream)['packages']
-                return pkgs if pkgs else []
-        else:
-            return []
-
     res = {}
     for org_name, repos in repo_index.items():
         for repo in repos:
@@ -62,12 +59,12 @@ def get_pkgs_with_updates(repo_index, version_index, path):
                 valid_remote_tags = version.get_valid_remote_tags(Repo(current_repo_path))
                 logging.info(f'pkg remote tags: {sorted(valid_remote_tags)}')
 
-                new_tags = list(valid_remote_tags - existing_tags) + ['0.7.2'] # TODO remove this
+                new_tags = list(valid_remote_tags - existing_tags)
                 if new_tags:
                     logging.info(f'adding new tags {list(new_tags)} to {package_name} repo')
                     if org_name not in res:
                         res[org_name] = {}
-                    res[org_name][repo] = (package_name, current_repo_path, new_tags)
+                    res[org_name][repo] = (package_name, current_repo_path, new_tags, existing_tags)
             else:
                 logging.warning(f'{repo} has no dbt_project.yml. Skipping...')
     return res
@@ -176,20 +173,21 @@ def make_spec(org, repo, package_name, packages, version, git_path):
         }
     }
 
-def commit_version_updates_to_hub(new_pkg_version_index, hub_dir_path):
-    '''input: {org_name: {repo_name:(package_name, [version tags])}}
+def commit_version_updates_to_hub(new_pkg_version_index, hub_dir_path, one_branch_per_repo=True):
+    '''input: {org_name: {repo_name:(package_name, repo_path, [version tags], [version_tags])}}
     output: {branch_name: hashmap of branch info}
     N.B. this function will make changes to the hub only
     '''
+    res = {}
     for org_name, new_repo_tags in new_pkg_version_index.items():
-        for repo, (package_name, current_repo_path, new_tags) in new_repo_tags.items():
+        for repo, (package_name, repo_path, new_tags, existing_tags) in new_repo_tags.items():
             os.chdir(hub_dir_path)
             repo_hub_version_dir = hub_dir_path / 'data' / 'packages' / org_name / package_name / 'versions'
             Path.mkdir(repo_hub_version_dir, parents=True, exist_ok=True)
 
             # in hub, on a branch for each package, commit the package version specs for any new tags
-            branch_name = cut_version_branch(org_name, repo, ONE_BRANCH_PER_REPO)
-            new_branches[branch_name] = {"org": org_name, "repo": package_name}
+            branch_name = cut_version_branch(org_name, repo, one_branch_per_repo)
+            res[branch_name] = {"org": org_name, "repo": package_name}
 
             # create an updated version of the repo's index.json
             index_file_path = hub_dir_path / 'data' / 'packages' / org_name / package_name / 'index.json'
@@ -198,9 +196,9 @@ def commit_version_updates_to_hub(new_pkg_version_index, hub_dir_path):
                 org_name,
                 repo,
                 package_name,
-                package.fetch_index_file_contents(index_file_path),
-                set(new_tags) | version.get_existing_tags(existing_pkg_version_index[org_name][repo]),
-                current_repo_path
+                fetch_index_file_contents(index_file_path),
+                set(new_tags) | set(existing_tags),
+                repo_path
             )
 
             with open(index_file_path, 'w') as f:
@@ -209,11 +207,17 @@ def commit_version_updates_to_hub(new_pkg_version_index, hub_dir_path):
 
             # create a version spec for each tag
             for tag in new_tags:
-                # TODO: patch in the code to get packages from each tag
-                package_spec = make_spec(org_name, repo, package_name, packages, tag, current_repo_path)
+                # go to repo dir to checkout tag and tag-commit specific package list
+                os.chdir(repo_path)
+                run_cmd(f'git tag')
+                run_cmd(f'git checkout tags/{tag}')
+                packages = parse_pkgs(Path(os.getcwd()))
+
+                # return to hub and build spec
+                os.chdir(hub_dir_path)
+                package_spec = make_spec(org_name, repo, package_name, packages, tag, repo_path)
 
                 version_path = repo_hub_version_dir / Path(f'{tag}.json')
-
                 with open(version_path, 'w') as f:
                     logging.info(f'writing spec to {version_path}')
                     f.write(str(json.dumps(package_spec, indent=4)))
@@ -222,8 +226,9 @@ def commit_version_updates_to_hub(new_pkg_version_index, hub_dir_path):
                 logging.info(msg)
                 run_cmd('git add -A')
                 subprocess.run(args=['git', 'commit', '-am', f'{msg}'], capture_output=True)
-                new_branches[branch_name]['new'] = True
 
+                res[branch_name]['new'] = True
             # good house keeping
             os.chdir(hub_dir_path)
             run_cmd('git checkout master')
+    return res

--- a/hubcap/setup.py
+++ b/hubcap/setup.py
@@ -7,6 +7,7 @@ import re
 import requests
 
 from pathlib import Path
+from cmd import *
 
 NOW = int(datetime.datetime.now().timestamp())
 NOW_ISO = datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()
@@ -18,12 +19,13 @@ logging.basicConfig(
 )
 
 def build_config():
-    config = json.loads(os.environ['CONFIG'])
-    config['tracked_repos'] = {}
+    return json.loads(os.environ['CONFIG'])
 
+def load_tracked_repo_records():
+    res = {}
     with open('hub.json', 'r') as hub_stream, open('exclusions.json') as excluded_stream:
         org_pkg_list = json.load(hub_stream)
-        # Mila: eventually we instead remove the packages at their source rather than this post-facto filtering
+        # Mila: eventually we should instead remove the packages at their source rather than this post-facto filtering
         excluded_pkg_list = json.load(excluded_stream)
 
         for org_name, org_pkg_names in org_pkg_list.items():
@@ -32,19 +34,21 @@ def build_config():
             ]
 
             if res_pkg_list:
-                config['tracked_repos'][org_name] = res_pkg_list
+                res[org_name] = res_pkg_list
+    return res
 
-    return config
 
-
-def build_version_index():
+def build_pkg_version_index(hub_path):
+    '''traverse the hub repo and load all versions for every package of every org into memory'''
+    prev_path = os.getcwd()
+    os.chdir(hub_path)
     index = collections.defaultdict(lambda : collections.defaultdict(list))
     pkg_version_indexes = [ filepath for filepath in (Path('data') / Path('packages')).glob('**/*.json')
                         if os.path.basename(filepath) != 'index.json' ]
 
     for path in pkg_version_indexes:
         org_name, repo_name = re.match(r'data/packages/(.+)/(.+)/versions', str(path)).groups()
-        info = {"path": path, "version": os.path.basename(path)[:-len('.json')]}
-        index[org_name][repo_name].append(info)
+        index[org_name][repo_name].append(os.path.basename(path)[:-len('.json')])
 
+    os.chdir(prev_path)
     return index

--- a/hubcap/version.py
+++ b/hubcap/version.py
@@ -2,8 +2,9 @@ import logging
 import os
 import re
 
+import package
+
 from cmd import *
-from package import *
 
 
 def is_valid_semver_tag(tag):
@@ -22,23 +23,16 @@ def strip_v_from_version(tag):
         return tag
 
 
-def get_existing_tags(pkg_index_records):
-    '''in: the version index of a package checked into hub
+def get_existing_tags(version_tags):
+    '''in: list of version tags
     out: only semver compliant tags'''
-    existing_hub_tags = { pkg_index_record['version'] for pkg_index_record in pkg_index_records }
-    return set(filter(is_valid_semver_tag, existing_hub_tags))
+    return set(filter(is_valid_semver_tag, version_tags))
 
 
-def get_new_tags(pkg_index_records):
+def get_valid_remote_tags(repo):
     '''designed to be run inside a package repo
     will not pick up tags other than those which are semver compliant'''
+    repo.git.fetch('--quiet', '--tags')
+    all_remote_tags = repo.git.tag('--list').split('\n')
 
-    run_cmd('git fetch --quiet --tags')
-    all_remote_tags = run_cmd('git tag --list', quiet=True).split('\n')
-    valid_remote_tags = set(filter(is_valid_semver_tag, all_remote_tags))
-    logging.info(f'remote tags: {sorted(valid_remote_tags)}')
-
-    existing_tags = get_existing_tags(pkg_index_records)
-    logging.info(f'hub tags:    {sorted(existing_tags)}')
-
-    return valid_remote_tags - existing_tags
+    return set(filter(is_valid_semver_tag, all_remote_tags))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+gitpython
 requests==2.20.1
 pyyaml


### PR DESCRIPTION
Closes #70 
Closes #44 

## Purpose

Next week, Fivetran packages will begin building from main rather than master. The script is now powered to pull updates from whichever branch is default in a package project, whether it's master, main, or something entirely different--it's agnostic as to what the name actually is.

In order to do this, I began hacking away at code which I've been meaning to for at least a week. In unraveling a very nested for loop setup into decoupled function interfaces, I was able to find the right placement to address the long-dreaded package-version spec bug. Below is some proof.

![image](https://user-images.githubusercontent.com/67295367/133771496-e337dfa7-a7a1-4370-8980-9086cea7159e.png)

The script generated this for an older version of dbt-expectations. [Here's what's currently checked into master of hub ](https://github.com/dbt-labs/hub.getdbt.com/blob/master/data/packages/calogica/dbt_expectations/versions/0.2.1.json) for this tag.

But, [here's what it should be](https://github.com/calogica/dbt-expectations/blob/0.2.0/packages.yml) -- same as the version generated by this new version of the script.

Moving forward, package readouts will be parsed from the packages.yml at the tag's specific commit sha. We've tried to fix this in the past with PR #45 but that didn't quite do the trick with the way the script was layered at the time. Drew proposed a different fix in a now closed PR. This is an attempt to mop up for good.

## Testing

It's mostly functions now which meant I could unit test as I went (and if wanted we can setup actual unit tests).

The script runs to completion as expected with no package updates to be made. It will generate a correct spec (technically one more correct than the production version of hubcap may run -- see the screenshot above) when there's at least one version to create.

## Side note

Fivetran's zuora repos are empty. This was causing bugs. I excluded them for now to get us moving.

Also, if you didn't notice, I move a decent amount of code around and began to employ the `gitPython` package which is quite decent today (even though old decade-old Stack overflow posts used to complain about it).

Lastly, to make things easier to debug, I added a command line option to preserve the commits and specs made throughout runtime so developers can peek more easily at what's going on under the hood.