### PR TITLE
Revert "Update hub.json"

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -160,8 +160,5 @@
     ],
     "avohq": [
         "avo_audit"
-    ],
-    "tuva-health": [
-        "staging"
     ]
 }


### PR DESCRIPTION
Reverts dbt-labs/hubcap#79

Package uses hard references that should be changed to variables, a consistent naming scheme, or ref-ed selects to ensure package is compatible with users whose schemata may not include public or specific base tables.