### PR TITLE
Add Matatika dbt-tap-googleads

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -173,5 +173,8 @@
     ],
     "avohq": [
         "avo_audit"
+    ],
+    "Matatika": [
+        "dbt-tap-googleads"
     ]
 }


### PR DESCRIPTION
Hi, could we please add our dbt-tap-googleads project to the hub.

We test this project daily end to end in our app. Behind the scenes this creates a Meltano project, adds a singer-tap, our dbt-tap-googleads project, and some datasets. Does a complete ETL and then we assert that our datasets, which work off the dbt models, contain data. 

This is the second PR we have, whichever gets merged in first we'll update the other PR.

Let me know if there is anything else you want to know or want me to change :)