### PR TITLE
Update dbt_artifacts GitHub organization to brooklyn-data

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -140,7 +140,7 @@
     "dbt-msft": [
         "tsql-utils"
     ],
-    "tailsdotcom": [
+    "brooklyn-data": [
         "dbt_artifacts"
     ],
     "emilyriederer": [


### PR DESCRIPTION
On 2021/12/20, the dbt_artifacts package repository was transferred from the tailsdotcom GitHub organization to brooklyn-data. https://github.com/brooklyn-data/dbt_artifacts