### PR TITLE
Remove dbt-labs/facebook_ads from exclusions.json

### DIFF
--- a/exclusions.json
+++ b/exclusions.json
@@ -13,7 +13,6 @@
       "taboola",
       "heap",
       "ecommerce",
-      "facebook-ads",
       "zendesk",
       "stripe",
       "purecloud"


### PR DESCRIPTION
As discussed with @VersusFacit to solve the updated packages not being pulled through to Hub
![image](https://user-images.githubusercontent.com/7335046/147988604-ebe83c55-e7dc-4d2b-8f9a-417505568717.png)
