### PR TITLE
Add splitgraph/ab2ft_stripe to hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -184,5 +184,8 @@
     ],
     "elementary-data": [
         "dbt-data-reliability"
+    ],
+    "splitgraph": [
+        "ab2ft_stripe"
     ]
 }


### PR DESCRIPTION
Hi! 👋

We recently open sourced [a package](https://github.com/splitgraph/ab2ft_stripe) that takes the raw JSON data output by [Airbyte's Stripe source](https://docs.airbyte.com/integrations/sources/stripe) and munges it in a way that makes it compatible with the [fivetran/dbt_stripe](https://github.com/fivetran/dbt_stripe) dbt model created by Fivetran for their Stripe connector.

All of the downstream `fivetran/dbt_stripe` dbt tests pass (after disabling the `using_payment_method` functionality, since Airbyte doesn't replicate that data from Stripe). Running this on our own Stripe data replicated with Airbyte produces weekly/monthly/quarterly report models that make sense, so thought it might be useful to other folks!