### PR TITLE
Add Matatika dbt-tap-meltano

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -177,7 +177,8 @@
     ],
     "Matatika": [
         "dbt-tap-googleads",
-        "dbt-tap-solarvista"
+        "dbt-tap-solarvista",
+        "dbt-tap-meltano"
     ],
     "tuva-health": [
         "tuva"


### PR DESCRIPTION
Hi, could we please get our dbt-tap-meltano into the hub.

For testing there are tests in the project itself, we also test this project daily end to end in our app. Behind the scenes this creates a Meltano project, adds a singer-tap, our dbt-tap-meltano project, and some datasets. Does a complete ETL and then we assert that our datasets, which work off the dbt models, contain data. This happens for both snowflake and postgres.

Let me know if there is anything else you want to know or want me to change :)
