### PR TITLE
Adding Sage Intacct Package for Fivetran

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -101,7 +101,9 @@
         "dbt_twitter_organic_source",
         "dbt_linkedin_pages",
         "dbt_linkedin_pages_source",
-        "dbt_social_media_reporting"
+        "dbt_social_media_reporting",
+        "dbt_sage_intacct",
+        "dbt_sage_intacct_source"
 
     ],
     "Montreal-Analytics": [


### PR DESCRIPTION
Mid March we are looking to release our next dbt package for Sage Intacct! This PR adds the `dbt_sage_intacct` and `dbt_sage_intacct_source` package to the Hub under Fivetran.