### PR TITLE
Add Matatika dbt-tap-trello and dbt-tap-google-analytics

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -181,7 +181,9 @@
     "Matatika": [
         "dbt-tap-googleads",
         "dbt-tap-solarvista",
-        "dbt-tap-meltano"
+        "dbt-tap-meltano",
+        "dbt-tap-trello",
+        "dbt-tap-google-analytics"
     ],
     "tuva-health": [
         "tuva"


### PR DESCRIPTION
Hi, could we please get our `dbt-tap-trello` and `dbt-tap-google-analytics` projects into the hub.

For testing there are tests in the Trello project, we also test these projects daily end to end in our app. Behind the scenes this creates a Meltano project, adds a singer-tap, our dbt-tap project, and some datasets. Does a complete ETL and then we assert that our datasets, which work off the dbt models, contain data. This happens for both snowflake and postgres.

Let me know if there is anything else you want to know or want me to change :)
