### PR TITLE
Add Matatika dbt-tap-spotify

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -184,7 +184,8 @@
         "dbt-tap-solarvista",
         "dbt-tap-meltano",
         "dbt-tap-trello",
-        "dbt-tap-google-analytics"
+        "dbt-tap-google-analytics",
+        "dbt-tap-spotify"
     ],
     "tuva-health": [
         "tuva"


### PR DESCRIPTION
Hey, could we please get our `dbt-tap-spotify` package into the hub.

For testing, alongside the in project tests, we test these projects daily end to end in our app.  Behind the scenes this creates a Meltano project, adds a singer-tap, our dbt-tap project, and some datasets. Does a complete ETL and then we assert that our datasets, which work off the dbt models, contain data. This happens for both snowflake and postgres.

Let me know if there is anything else wanted/needed :)