### PR TITLE
Added facebook ads and Pipedrive dbt packages

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -26,10 +26,12 @@
         "dbt_metrics"
     ],
     "cerebriumai": [
+        "airbyte_dbt_intercom",
+        "airbyte_dbt_facebook_ads",
         "airbyte_dbt_github",
         "airbyte_dbt_google_ads",
+        "airbyte_dbt_pipedrive",
         "airbyte_dbt_shopify",
-        "airbyte_dbt_intercom",
         "airbyte_dbt_stripe"
     ],
     "fivetran": [


### PR DESCRIPTION
Added Facebook Ads and Pipedrive DBT packages for the Airbyte connectors