### PR TITLE
Add `dbt-ga4` to dbt hub

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -234,5 +234,8 @@
         "dlh-quickbooks-analytics-dbt",
         "dlh-xero-analytics-dbt",
         "dlh-salesforce-analytics-dbt"
+    ],
+    "Velir": [
+        "dbt-ga4"
     ] 
 }


### PR DESCRIPTION
This package serves as an accelerator for those working with Google Analytics 4 data in BigQuery. 