### PR TITLE
Add everpeace/dbt-models-metadata package

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -245,7 +245,7 @@
     "hightouchio": [
         "dbt-hightouch"
     ],
-    "everpeace" [
+    "everpeace": [
         "dbt-models-metadata"
     ]
 }

--- a/hub.json
+++ b/hub.json
@@ -244,5 +244,8 @@
     ],
     "hightouchio": [
         "dbt-hightouch"
+    ],
+    "everpeace" [
+        "dbt-models-metadata"
     ]
 }


### PR DESCRIPTION
[everpeace/dbt-models-metadata](https://github.com/everpeace/dbt-models-metadata) can builds models’ metadata table along side your project models by utilizing `run-on-end` hook. 

The generated metadata table contains model’s not only basic information(database, schema, table, description) but also execution information from the run_result.json.  Thus the metadata can serve as simple data catalog and helps analysts to understand when and how models were built by dbt. Of course dbt doc would be great help.  But I think metadata table alongside the models are very handy for them to get in touch with models’ metadata.  Moreover, this package support to define user-defined additional columns to the metadata table which might contain supplemental information (e.g. git information(repo url, commit hash, etc.) or CI job’s information that generates the models).

The difference against [dbt-labs/dbt-event-logging](https://github.com/dbt-labs/dbt-event-logging) are belows:

- my package focuses on building metadata table for models instead of auditing and logging.
- my package is based on `run_result.json`. this can report more details of dbt command execution (e.g. `adapter_response`, `timing`, parsed `node` data, etc.)
- my package supports custom column that user can append git/CI information to the metadata table.

fixes https://github.com/everpeace/dbt-models-metadata/issues/11