### PR TITLE
Add `yu-iskw/dbt-unittest`

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -150,7 +150,8 @@
         "dbt_constraints"
     ],
     "yu-iskw": [
-        "dbt-airflow-macros"
+        "dbt-airflow-macros",
+        "dbt-unittest"
     ],
     "tnightengale": [
         "dbt-meta-testing"


### PR DESCRIPTION
## Overview
I created a dbt package like python's `unittest`, as many dbt packages contain their own custom assertion macros. So, the package enables dbt package developers to reuse common assertion dbt macros.

https://github.com/yu-iskw/dbt-unittest