### PR TITLE
Make `published_at` a constant

### DIFF
--- a/hubcap/records.py
+++ b/hubcap/records.py
@@ -174,7 +174,7 @@ class UpdateTask(object):
             "id": "{}/{}/{}".format(org, package_name, version),
             "name": package_name,
             "version": version,
-            "published_at": setup.NOW_ISO,
+            "published_at": "1970-01-01T00:00:00.000000+00:00",
             "packages": packages,
             "works_with": [],
             "_source": {

--- a/hubcap/setup.py
+++ b/hubcap/setup.py
@@ -13,7 +13,6 @@ from git_helper import *
 from records import *
 
 NOW = int(datetime.datetime.now().timestamp())
-NOW_ISO = datetime.datetime.now(datetime.timezone.utc).astimezone().isoformat()
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)-8s %(message)s',


### PR DESCRIPTION
## Problem
`published_at` appears to be unused, but [it causes 100's of extraneous merge conflicts that have to be resolved by hand](https://github.com/dbt-labs/hub.getdbt.com/issues/1484) by a maintainer.

## Design aspirations
- **don't break anything** for our user base (dbt Cloud and dbt Core `dbt deps` users)
- solve this with the least amount of changes
- solve this with the least amount of time investment
- minimize the risk footprint of unknown and unanticipated uses of the `published_at` attribute

## Solution
Treat it as vestigial and set it to a clearly non-applicable constant value

## Consequences

### Summary
I can live with it if this change causes some arcane pipeline to break -- the perceived payoff outweighs the perceived risks.

I would be devastated if this change affected dbt Cloud and dbt Core `dbt deps` users -- it stands to reason that it shouldn't, and I've done reasonable testing that it won't.

### Details
- We've already needed to [close 100's of pull requests by hand](https://github.com/dbt-labs/hub.getdbt.com/issues/1484), but this should put an end to that necessity 🎉 
- The `published_at` attribute continues to be retained for the future, even though we have no knowledge of it ever being functional.
    - This should help reduce the risk of some unanticipated pipeline breaking due to a "key not found error"
    - **Note:** There are other attributes in the same JSON payload that appear to be non-functional, too.
- The `published_at` attribute value going forward will be a constant aligning with the UNIX epoch: `1970-01-01T00:00:00.000000+00:00`
- No one _should_ sort on this attribute -- sorting should only be done according to parsing the semantic version number
    - If there are downstream consumers of this attribute that sort temporally, any versions released after this change will sort to the front (potentially earlier than previous versions
    
## Testing
The change is within this repository, but the effect is within [hub.getdbt.com](https://github.com/dbt-labs/hub.getdbt.com). The former has a testing framework now (but barely any tests), whereas the latter has no testing at all that I'm aware of.

To test, I did the following:
1. Created a [public GitHub project for a package not currently in the Hub](https://github.com/dbeatty10/mrr-playbook/tree/1.0.0)
1. Made the relevant changes to Hubcap locally
1. Executed the `cron.sh` script (in `test` mode, with `--` enabled)
1. Changed directories into `git-tmp/hub` (which contains a clone of the hub.getdbt.com project!)
1. Launched a localhost version of the hub.getdbt.com website from that location
1. Using the `DBT_PACKAGE_HUB_URL` environment variable, successfully installed version `1.0.0` of the `dbeatty10/mrr-playbook` package 🎉 

I also did local testing with removing the `published_at` key from the JSON blob entirely.
I did not try retaining the key but using a null or blank value.

### Resources
- [dbt-labs/hubcap CONTRIBUTING](https://github.com/dbt-labs/hubcap/blob/f3e0de896580d9ebaefbeb11e6ea999ec7a9c69e/CONTRIBUTING.md)
- [dbt-labs/hub.getdbt.com CONTRIBUTING](https://github.com/dbt-labs/hub.getdbt.com/blob/master/CONTRIBUTING.md)