### PR TITLE
Add `require_dbt_version` to Hub API

### DIFF
--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -31,6 +31,12 @@ def parse_pkg_name(repo_dir):
         return name if name else ''
 
 
+def parse_require_dbt_version(repo_dir):
+    with open(repo_dir / Path('dbt_project.yml'), 'r') as stream:
+        requirements = yaml.safe_load(stream).get('require-dbt-version', [])
+        return requirements if requirements else []
+
+
 def parse_pkgs(repo_dir):
     if os.path.exists(repo_dir / 'packages.yml'):
         with open(repo_dir / Path('packages.yml'), 'r') as stream:

--- a/hubcap/records.py
+++ b/hubcap/records.py
@@ -177,7 +177,8 @@ class UpdateTask(object):
             "version": version,
             "published_at": "1970-01-01T00:00:00.000000+00:00",
             "packages": packages,
-            "works_with": require_dbt_version,
+            "require_dbt_version": require_dbt_version,
+            "works_with": [],
             "_source": {
                 "type": "github",
                 "url": "https://github.com/{}/{}/tree/{}/".format(org, repo, version),


### PR DESCRIPTION
resolves https://github.com/dbt-labs/hub.getdbt.com/issues/165

~What is `works_with` used for? Is this the old name for `packages`? It's not being used for anything by recent versions of `dbt-core`.~

I've added a totally new field to the hub API (`require_dbt_version`). ~I just started by reusing the existing field for expediency.~

I tested the simple methods locally, against `dbt_project.yml` files that do and don't have `require-dbt-version` defined. Note that this _will not_ work unless `require-dbt-version` is a valid semver string/list (as documented), so we probably want to add some validation logic to that effect.

As far as moving forward with this:
- Not sure of the right way to end-to-end test this
- Would we want to rerun the Hubcap script, to update existing package versions?