### PR TITLE
Enable pull requests to be either consolidated or individual

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@
 
 ### Personal access token (PAT)
 
-Follow [these](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) instructions to configurate a personal access token.
+Follow [these](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) instructions to configure a PAT.
 
-Only permissions needed:
-- public_repo
+Scopes:
+- repo (and all sub-items)
+- workflow
 
 Save the token to a secure location. Click the "Configure SSO" button and "Authorize" if applicable.
 
@@ -49,7 +50,7 @@ export ENV=test
 ```
 
 ### Optional configuration environment variables
-```
+```shell
 # Default value is the `git-tmp` directory within the current working directory
 # This directory will be deleted by default at the end of the run
 export GIT_TMP=git-tmp
@@ -57,7 +58,7 @@ export GIT_TMP=git-tmp
 
 ### Optional parameters
 Preserve commits/build artifacts within the `$GIT_TMP` directory
-```
+```shell
 export ENV=test
 ./cron.sh --no-cleanup
 ```

--- a/config.example.json
+++ b/config.example.json
@@ -3,7 +3,8 @@
         "name": "github_user",
         "token": "pe4s0n@l-@cce$$-t0k3n"
     },
-    "remote": "git@github.com:dbt-labs/hub.getdbt.com.git",
+    "org": "dbt-labs",
+    "repo": "hub.getdbt.com",
     "push_branches": true,
     "one_branch_per_repo": true
 }

--- a/cron.sh
+++ b/cron.sh
@@ -75,7 +75,7 @@ if [ "$ENV" = 'prod' ] || [ "$ENV" = 'test' ]; then
     PRIOR_GIT_NAME="$(git config --global user.name || : )"
 
     # Setup git repo for automated commits during execution
-    git config --global user.email 'drew@fishtownanalytics.com'  # TODO: make this a dedicated CI user
+    git config --global user.email 'buildbot@fishtownanalytics.com'
     git config --global user.name 'dbt-hubcap'
 fi
 

--- a/hubcap/git_helper.py
+++ b/hubcap/git_helper.py
@@ -41,11 +41,17 @@ def repo_default_branch(repo):
 
 def clone_repo(remote, path):
     '''Clone down a github repo to a path and a reference to that directory'''
-    logging.info(f'cloning {remote} to {path}')
-    repo = Repo.clone_from(remote, path)
+
+    if Path(path).is_dir():
+        logging.info(f'already exists: {path}')
+        repo = Repo(path)
+    else:
+        logging.info(f'cloning {remote} to {path}')
+        repo = Repo.clone_from(remote, path)
 
     main_branch = repo_default_branch(repo)
     repo.git.checkout(main_branch)
+    logging.info(f'pulling {main_branch} at {path}')
     repo.remotes.origin.pull()
     return path
 

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -22,6 +22,7 @@ config = setup.build_config()
 
 github_org = config.get("org", "dbt-labs")
 github_repo = config.get("repo", "hub.getdbt.com")
+push_branches = config.get("push_branches", True)
 REMOTE = f"git@github.com:{github_org}/{github_repo}.git"
 TMP_DIR = os.environ['GIT_TMP']
 TOKEN = config['user']['token']
@@ -57,4 +58,4 @@ new_branches = package.commit_version_updates_to_hub(update_tasks, hub_dir_path)
 
 logging.info("Pushing branches: {}".format(list(new_branches.keys())))
 if new_branches:
-    release_carrier.open_new_prs(hub_dir_path, REMOTE, new_branches, config['user'])
+    release_carrier.open_new_prs(hub_dir_path, REMOTE, new_branches, config['user'], push_branches)

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -12,6 +12,8 @@ import release_carrier
 
 from git_helper import *
 from records import *
+from records import IndividualPullRequests, ConsolididatedPullRequest
+
 
 # ==
 # == Build global state
@@ -23,11 +25,17 @@ config = setup.build_config()
 github_org = config.get("org", "dbt-labs")
 github_repo = config.get("repo", "hub.getdbt.com")
 push_branches = config.get("push_branches", True)
+one_branch_per_repo = config.get("one_branch_per_repo", True)
 REMOTE = f"git@github.com:{github_org}/{github_repo}.git"
 PULL_REQUEST_URL = f"https://api.github.com/repos/{github_org}/{github_repo}/pulls"
 TMP_DIR = os.environ['GIT_TMP']
 TOKEN = config['user']['token']
 PACKAGE_MAINTAINERS = setup.load_package_maintainers()
+
+if one_branch_per_repo:
+    pr_strategy = IndividualPullRequests()
+else:
+    pr_strategy = ConsolididatedPullRequest()
 
 # pull down hub to assess current state and have ready for future commits
 hub_dir_path = clone_repo(REMOTE, TMP_DIR / Path('hub'))
@@ -51,7 +59,7 @@ update_tasks = package.get_update_tasks(PACKAGE_MAINTAINERS, HUB_VERSION_INDEX, 
 
 logging.info('preparing branches for packages with versions to be added')
 # this wants to take place inside the git-tmp/hub repo
-new_branches = package.commit_version_updates_to_hub(update_tasks, hub_dir_path)
+new_branches = package.commit_version_updates_to_hub(update_tasks, hub_dir_path, pr_strategy)
 
 # =
 # = push new branches, if there are any
@@ -59,4 +67,4 @@ new_branches = package.commit_version_updates_to_hub(update_tasks, hub_dir_path)
 
 logging.info("Pushing branches: {}".format(list(new_branches.keys())))
 if new_branches:
-    release_carrier.open_new_prs(hub_dir_path, REMOTE, new_branches, config['user'], push_branches, PULL_REQUEST_URL)
+    release_carrier.open_new_prs(hub_dir_path, REMOTE, new_branches, config['user'], push_branches, PULL_REQUEST_URL, pr_strategy)

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -24,6 +24,7 @@ github_org = config.get("org", "dbt-labs")
 github_repo = config.get("repo", "hub.getdbt.com")
 push_branches = config.get("push_branches", True)
 REMOTE = f"git@github.com:{github_org}/{github_repo}.git"
+PULL_REQUEST_URL = f"https://api.github.com/repos/{github_org}/{github_repo}/pulls"
 TMP_DIR = os.environ['GIT_TMP']
 TOKEN = config['user']['token']
 PACKAGE_MAINTAINERS = setup.load_package_maintainers()
@@ -58,4 +59,4 @@ new_branches = package.commit_version_updates_to_hub(update_tasks, hub_dir_path)
 
 logging.info("Pushing branches: {}".format(list(new_branches.keys())))
 if new_branches:
-    release_carrier.open_new_prs(hub_dir_path, REMOTE, new_branches, config['user'], push_branches)
+    release_carrier.open_new_prs(hub_dir_path, REMOTE, new_branches, config['user'], push_branches, PULL_REQUEST_URL)

--- a/hubcap/hubcap.py
+++ b/hubcap/hubcap.py
@@ -20,7 +20,9 @@ from records import *
 logging.info('preparing script state')
 config = setup.build_config()
 
-REMOTE = config['remote']
+github_org = config.get("org", "dbt-labs")
+github_repo = config.get("repo", "hub.getdbt.com")
+REMOTE = f"git@github.com:{github_org}/{github_repo}.git"
 TMP_DIR = os.environ['GIT_TMP']
 TOKEN = config['user']['token']
 PACKAGE_MAINTAINERS = setup.load_package_maintainers()

--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -105,7 +105,7 @@ def get_update_tasks(maintainers, version_index, path):
     ]
 
 
-def commit_version_updates_to_hub(tasks, hub_dir_path):
+def commit_version_updates_to_hub(tasks, hub_dir_path, pr_strategy):
     '''input: UpdateTask
     output: {branch_name: hashmap of branch info}
     N.B. this function will make changes to the local copy of hub only
@@ -113,7 +113,7 @@ def commit_version_updates_to_hub(tasks, hub_dir_path):
     res = {}
     for task in tasks:
         # major side effect is to commit on a new branch package updates
-        branch_name, org_name, package_name = task.run(hub_dir_path)
+        branch_name, org_name, package_name = task.run(hub_dir_path, pr_strategy)
         res[branch_name] = {"org": org_name, "repo": package_name}
 
         # good house keeping

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -9,11 +9,11 @@ from git import Repo
 from git.remote import Remote
 
 
-def make_pr(org, repo, head, user_creds, url):
+def make_pr(org, repo, head, user_creds, url, pr_strategy):
     '''Create POST content which in turns create a hub new-version PR'''
     user = user_creds['name']
     token = user_creds['token']
-    title = "HubCap: Bump {}/{}".format(org, repo)
+    title = pr_strategy.pull_request_title(org, repo)
     base = "master"
     body = "Auto-bumping from new release at https://github.com/{}/{}/releases".format(org, repo)
     maintainer_can_modify = True
@@ -51,7 +51,7 @@ def is_open_pr(prs, org_name, pkg_name):
     return any('{}/{}'.format(org_name, pkg_name) in pr for pr in prs)
 
 
-def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branches, pull_request_url):
+def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branches, pull_request_url, pr_strategy):
     '''Expects: {branch_name: hashmap of branch info} and {user_name, access token}
     will push prs up to a github remote'''
 
@@ -68,6 +68,7 @@ def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branch
 
     pr_branches = { name: info for name, info in branches.items()
                     if not is_open_pr(name, info['org'], info['repo'])}
+
     for name, info in branches.items():
         if name not in pr_branches.keys():
             setup.logging.info("PR is already open for {}/{}. Skipping.".format(info['org'], info['repo']))
@@ -79,6 +80,6 @@ def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branch
         if push_branches:
             setup.logging.info(f"Pushing and PRing branch {branch}")
             origin = target_repo.git.push('origin', branch)
-            make_pr(info['org'], info['repo'], branch, user_creds, pull_request_url)
+            make_pr(info['org'], info['repo'], branch, user_creds, pull_request_url, pr_strategy)
         else:
             setup.logging.info(f"Not pushing and PRing branch {branch}")

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -45,7 +45,8 @@ def open_new_prs(target_repo_path, remote_url, branches, user_creds):
     will push prs up to a github remote'''
 
     target_repo = Repo(target_repo_path)
-    target_repo.create_remote('hub', url=remote_url)
+    if not Remote(target_repo, 'hub').exists():
+        target_repo.create_remote('hub', url=remote_url)
 
     *_, target_org, target_pkg = remote_url.split('/')
     target_pkg_name = target_pkg[:-len('.git')]

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -9,13 +9,13 @@ from git import Repo
 from git.remote import Remote
 
 
-def make_pr(ORG, REPO, head, user_creds, url):
+def make_pr(org, repo, head, user_creds, url):
     '''Create POST content which in turns create a hub new-version PR'''
     user = user_creds['name']
     token = user_creds['token']
-    title = "HubCap: Bump {}/{}".format(ORG, REPO)
+    title = "HubCap: Bump {}/{}".format(org, repo)
     base = "master"
-    body = "Auto-bumping from new release at https://github.com/{}/{}/releases".format(ORG, REPO)
+    body = "Auto-bumping from new release at https://github.com/{}/{}/releases".format(org, repo)
     maintainer_can_modify = True
     post_pr(title, head, base, body, maintainer_can_modify, user, token, url)
 

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -49,6 +49,9 @@ def open_new_prs(target_repo_path, remote_url, branches, user_creds):
         target_repo.create_remote('hub', url=remote_url)
 
     *_, target_org, target_pkg = remote_url.split('/')
+    # Strip off "git@github.com:" from the beginning of the organization name
+    target_org = target_org.replace("git@github.com:", "")
+    # Strip off ".git" from the end of the package name
     target_pkg_name = target_pkg[:-len('.git')]
     open_pr_titles = get_open_pr_titles(target_org, target_pkg_name, user_creds)
 

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -51,6 +51,17 @@ def is_open_pr(prs, org_name, pkg_name):
     return any('{}/{}'.format(org_name, pkg_name) in pr for pr in prs)
 
 
+def get_org_repo(remote_url: str) -> str:
+    '''Parse the organization and repository from a GitHub remote URL.'''
+    *_, target_org, target_pkg = remote_url.split('/')
+    # Strip off "git@github.com:" from the beginning of the organization name
+    target_org = target_org.replace("git@github.com:", "")
+    # Strip off ".git" from the end of the package name
+    target_pkg_name = target_pkg[:-len('.git')]
+
+    return target_org, target_pkg_name
+
+
 def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branches, pull_request_url, pr_strategy):
     '''Expects: {branch_name: hashmap of branch info} and {user_name, access token}
     will push prs up to a github remote'''
@@ -59,11 +70,7 @@ def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branch
     if not Remote(target_repo, 'hub').exists():
         target_repo.create_remote('hub', url=remote_url)
 
-    *_, target_org, target_pkg = remote_url.split('/')
-    # Strip off "git@github.com:" from the beginning of the organization name
-    target_org = target_org.replace("git@github.com:", "")
-    # Strip off ".git" from the end of the package name
-    target_pkg_name = target_pkg[:-len('.git')]
+    target_org, target_pkg_name = get_org_repo(remote_url)
     open_pr_titles = get_open_pr_titles(target_org, target_pkg_name, user_creds)
 
     pr_branches = { name: info for name, info in branches.items()

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -9,9 +9,8 @@ from git import Repo
 from git.remote import Remote
 
 
-def make_pr(ORG, REPO, head, user_creds):
+def make_pr(ORG, REPO, head, user_creds, url):
     '''Create POST content which in turns create a hub new-version PR'''
-    url = 'https://api.github.com/repos/dbt-labs/hub.getdbt.com/pulls'
     body = {
         "title": "HubCap: Bump {}/{}".format(ORG, REPO),
         "head": head,
@@ -23,7 +22,8 @@ def make_pr(ORG, REPO, head, user_creds):
 
     user = user_creds['name']
     token = user_creds['token']
-    req = requests.post(url, data=body, headers={'Content-Type': 'application/json'}, auth=(user, token))
+    response = requests.post(url, data=body, headers={'Content-Type': 'application/json'}, auth=(user, token))
+    response.raise_for_status()
 
 
 def get_open_pr_titles(org_name, package_name, user_creds):
@@ -42,7 +42,7 @@ def is_open_pr(prs, org_name, pkg_name):
     return any('{}/{}'.format(org_name, pkg_name) in pr for pr in prs)
 
 
-def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branches):
+def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branches, pull_request_url):
     '''Expects: {branch_name: hashmap of branch info} and {user_name, access token}
     will push prs up to a github remote'''
 
@@ -70,6 +70,6 @@ def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branch
         if push_branches:
             setup.logging.info(f"Pushing and PRing branch {branch}")
             origin = target_repo.git.push('origin', branch)
-            make_pr(info['org'], info['repo'], branch, user_creds)
+            make_pr(info['org'], info['repo'], branch, user_creds, pull_request_url)
         else:
             setup.logging.info(f"Not pushing and PRing branch {branch}")

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -6,6 +6,8 @@ import os
 import setup
 
 from git import Repo
+from git.remote import Remote
+
 
 def make_pr(ORG, REPO, head, user_creds):
     '''Create POST content which in turns create a hub new-version PR'''

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -40,7 +40,7 @@ def is_open_pr(prs, org_name, pkg_name):
     return any('{}/{}'.format(org_name, pkg_name) in pr for pr in prs)
 
 
-def open_new_prs(target_repo_path, remote_url, branches, user_creds):
+def open_new_prs(target_repo_path, remote_url, branches, user_creds, push_branches):
     '''Expects: {branch_name: hashmap of branch info} and {user_name, access token}
     will push prs up to a github remote'''
 
@@ -65,7 +65,9 @@ def open_new_prs(target_repo_path, remote_url, branches, user_creds):
         target_repo.git.checkout(branch)
         target_repo.git.fetch('hub')
 
-        if os.environ['ENV'] == 'prod':
-            setup.logging.info("pushing and PRing for {}/{}".format(info['org'], info['repo']))
+        if push_branches:
+            setup.logging.info(f"Pushing and PRing branch {branch}")
             origin = target_repo.git.push('origin', branch)
             make_pr(info['org'], info['repo'], branch, user_creds)
+        else:
+            setup.logging.info(f"Not pushing and PRing branch {branch}")

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -11,17 +11,26 @@ from git.remote import Remote
 
 def make_pr(ORG, REPO, head, user_creds, url):
     '''Create POST content which in turns create a hub new-version PR'''
+    user = user_creds['name']
+    token = user_creds['token']
+    title = "HubCap: Bump {}/{}".format(ORG, REPO)
+    base = "master"
+    body = "Auto-bumping from new release at https://github.com/{}/{}/releases".format(ORG, REPO)
+    maintainer_can_modify = True
+    post_pr(title, head, base, body, maintainer_can_modify, user, token, url)
+
+
+def post_pr(title, head, base, body, maintainer_can_modify, user, token, url):
+    '''Create POST content which in turns create a hub new-version PR'''
     body = {
-        "title": "HubCap: Bump {}/{}".format(ORG, REPO),
+        "title": title,
         "head": head,
-        "base": "master",
-        "body": "Auto-bumping from new release at https://github.com/{}/{}/releases".format(ORG, REPO),
-        "maintainer_can_modify": True
+        "base": base,
+        "body": body,
+        "maintainer_can_modify": maintainer_can_modify
     }
     body = json.dumps(body)
 
-    user = user_creds['name']
-    token = user_creds['token']
     response = requests.post(url, data=body, headers={'Content-Type': 'application/json'}, auth=(user, token))
     response.raise_for_status()
 


### PR DESCRIPTION
## Problem
Currently, [github.com/dbt-labs/hub.getdbt.com](https://github.com/dbt-labs/hub.getdbt.com/pulls) is limited to merging only a single pull request per hour. That means a maximum of 24 new versions can be released per day. As an unfortunate side-effect, tons of duplicate pull requests also get generated.

## Solution

This pull request achieves multiple things:
1. commits can _optionally_ be gathered into a **single pull request** rather than one pull request per repo
1. an alternative destination repo for pull requests can be configured
    - this is handy for testing & development
1. the `git-tmp` directory can be preserved across executions
    - this is handy for inspecting the state of branches and commits

## Why

We ❤️ our friends at Fivetran (e.g, @fivetran-joemarkiewicz @fivetran-sheringuyen, etc), and switching on the **single/consolidated pull request** option would allow them to release with impunity.

## On the other hand
The **individual pull requests** option is the current behavior, and intend for it to still be the default immediately after this PR is merged. Hopefully we can switch to the consolidated PR option some time afterwards, and it will be easy to switch back to the original if we want.

## Usage

### consolidated PR
To switch to a single consolidated PR instead of individual PRs:
- update the `CONFIG` environment variable to contain `"one_branch_per_repo": false` rather than `"one_branch_per_repo": true`.

### development target repo
To use an alternative (development) repo rather than the production repo:
- update the `CONFIG` environment variable to contain something like `"repo": "hub.getdbt.com-test"` rather than `"repo": "hub.getdbt.com"`.

This assumes that a target repo with the name `hub.getdbt.com-test` has already been created and published!

### preserve clones across executions
To preserve the `git-tmp` directory between (local) executions:
- Execute with `./cron.sh --no-cleanup` rather than just `./cron.sh`