### PR TITLE
Restore the original git user

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -75,7 +75,7 @@ if [ "$ENV" = 'prod' ] || [ "$ENV" = 'test' ]; then
     PRIOR_GIT_NAME="$(git config --global user.name || : )"
 
     # Setup git repo for automated commits during execution
-    git config --global user.email 'buildbot@fishtownanalytics.com'
+    git config --global user.email 'drew@fishtownanalytics.com' # TODO: make this a dedicated CI user
     git config --global user.name 'dbt-hubcap'
 fi
 


### PR DESCRIPTION
The git user can be upgraded to a dedicated CI user during or after resolution of #160 and/or #162.