### PR TITLE
adding terminology package to tuva-health

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -269,7 +269,8 @@
         "core",
         "chronic_conditions",
         "readmissions",
-        "medicare_claims_connector"
+        "medicare_claims_connector",
+        "terminology"
     ],
     "yu-iskw": [
         "dbt-airflow-macros",


### PR DESCRIPTION
Trying a fresh pull request with the same content as https://github.com/dbt-labs/hubcap/pull/201 to address unknown Synk issue.

> Hi!
> 
> At Tuva we're in the middle of a big code overhaul. Our first step is adding the terminology package to dbt hub, which will be a dependency of many of our other packages. Ultimately we're moving towards one mono-package that inherits all of our other packages as dependencies, making it easier to configure and deploy our code base.
> 
> Let me know if you have any questions! Thanks,
> Forrest