### PR TITLE
Update hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -266,10 +266,11 @@
         "dbt-meta-testing"
     ],
     "tuva-health": [
-        "core",
+        "the_tuva_project",
         "chronic_conditions",
+        "claims_preprocessing",
+        "data_profiling",
         "readmissions",
-        "medicare_claims_connector",
         "terminology"
     ],
     "yu-iskw": [


### PR DESCRIPTION
Hi!  A few changes here as part of our code refactor:
- we renamed our "core" package to "the_tuva_project" (once the other packages are on dbt hub, we'll do a new release for this repo that will transform it into a mono-package implementing the rest of the packages)
- added data_profiling
- added claims_preprocessing
- removed medicare_claims_connector (for now, we're going to be using this repo as a project) -- note, something weird happened, I think when we renamed the medicare_claims_connector repo and named it back, dbt-hub now shows medicare_cclf_connector and medicare_claims_connector, even though only medicare claims_connector is in hubcap.json.  They can both be removed.