### PR TITLE
Add Narrator's activity schema package to dbt hub

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -229,6 +229,9 @@
         "dbt-datamocktool",
         "dbt_product_analytics"
     ],
+    "narratorai": [
+        "dbt-activity-schema"
+    ],
     "omnata-labs": [
         "dbt-ml-preprocessing"
     ],


### PR DESCRIPTION
## Description 

This package has some macros to help when building an [activity schema](https://github.com/ActivitySchema/ActivitySchema) in dbt. It helps build out a json column across warehouses and helps fill out some important computed columns (activity_repeated_at and activity_occurrence). 

We're also planning on building a set of packages for building activity stream tables from specific sources (segment, stripe, zendesk, etc). This forms the basis of those as well. 

## Checklist
This checklist is a cut down version of the [best practices](package-best-practices.md) that we have identified as the package hub has grown. Although meeting these checklist items is not a prerequisite to being added to the Hub, we have found that packages which don't conform provide a worse user experience. 

### First run experience
- [x] The package includes a README which explains how to get started with the package and customise its behaviour
- [x] The README indicates which data warehouses/platforms are expected to work with this package

### Customisability
- [x] The package uses ref or source, instead of hard-coding table references.

### Dependencies
#### Dependencies on dbt Core
- [x] The package has set a supported `require-dbt-version` range in `dbt_project.yml`. Example: A package which depends on functionality added in dbt Core 1.2 should set its `require-dbt-version` property to `[">=1.2.0", "<2.0.0"]`.

### Interoperability
- [x] The package does not override dbt Core behaviour in such a way as to impact other dbt resources (models, tests, etc) not provided by the package.
- [x] The package uses the cross-database macros built into dbt Core where available, such as `{{ dbt.except() }}` and `{{ dbt.type_string() }}`.
- [x] The package disambiguates its resource names to avoid clashes with nodes that are likely to already exist in a project. For example, packages should not provide a model simply called `users`.

### Versioning
- [x] (Required): The package's git tags validates against the regex defined in [version.py](/hubcap/version.py)
   - version.py doesn't seem to exist, but this is version v0.1.0, which is part of semvar and should pass
- [x] The package's version follows the guidance of Semantic Versioning 2.0.0. (Note in particular the recommendation for production-ready packages to be version 1.0.0 or above)
