### PR TITLE
Update hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -202,7 +202,9 @@
         "dbt_amplitude",
         "dbt_amplitude_source",
         "dbt_recurly",
-        "dbt_recurly_source"
+        "dbt_recurly_source",
+        "dbt_amazon_ads",
+        "dbt_amazon_ads_source"
     ],
     "get-select": [
         "dbt-snowflake-monitoring"


### PR DESCRIPTION
## Description 

The new Amazon Ads (and Source) packages developed by @fivetran-catfritz will follow the same nature of the existing Fivetran Ad packages and will roll up into the [Ad Reporting](https://github.com/fivetran/dbt_ad_reporting) dbt package. This package will produced modeled tables that leverage the Amazon Ads data from Fivetran's connector. It will enable customers to better understand the performance of their ads across varying grains: account, portfolio, campaign, ad group, keyword, and ad level reports.

Please be aware that the README and integration tests of the Amazon Ads package are still in development. They are likely to be completed the second week of January. However, I wanted to get ahead of my tasks and ensure I opened this PR sooner than later. Let me know if you have any questions! 😄 

## Checklist
This checklist is a cut down version of the [best practices](package-best-practices.md) that we have identified as the package hub has grown. Although meeting these checklist items is not a prerequisite to being added to the Hub, we have found that packages which don't conform provide a worse user experience. 

### First run experience
- [X] The package includes a README which explains how to get started with the package and customise its behaviour
- [X] The README indicates which data warehouses/platforms are expected to work with this package

### Customisability
- [X] The package uses ref or source, instead of hard-coding table references.
#### Packages for data transformation (delete if not relevant):
- [X] provide a mechanism (such as variables) to customise the location of source tables.
- [X] do not assume database/schema names in sources.

### Dependencies
#### Dependencies on dbt Core
- [X] The package has set a supported `require-dbt-version` range in `dbt_project.yml`. Example: A package which depends on functionality added in dbt Core 1.2 should set its `require-dbt-version` property to `[">=1.2.0", "<2.0.0"]`.
#### Dependencies on other packages defined in packages.yml:
- [X] Dependencies are imported from the dbt Package Hub when available, as opposed to a git installation.
- [X] Dependencies contain the widest possible range of supported versions, to minimise issues in dependency resolution.
- [X] In particular, dependencies are not pinned to a patch version unless there is a known incompatibility.
### Interoperability
- [X] The package does not override dbt Core behaviour in such a way as to impact other dbt resources (models, tests, etc) not provided by the package.
- [X] The package uses the cross-database macros built into dbt Core where available, such as `{{ dbt.except() }}` and `{{ dbt.type_string() }}`.
- [X] The package disambiguates its resource names to avoid clashes with nodes that are likely to already exist in a project. For example, packages should not provide a model simply called `users`.

### Versioning
- [X] (Required): The package's git tags validates against the regex defined in [version.py](/hubcap/version.py)
- [X] The package's version follows the guidance of Semantic Versioning 2.0.0. (Note in particular the recommendation for production-ready packages to be version 1.0.0 or above)
