### PR TITLE
Re-add dbt-graph-theory package

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -227,6 +227,9 @@
     "jitsucom": [
         "dbt-jitsu"
     ],
+    "jpmmcneill": [
+        "dbt-graph-theory"
+    ],
     "kristeligt-dagblad": [
         "dbt_ml"
     ],


### PR DESCRIPTION
Resolves #230

This re-adds the dbt-graph-theory package by reverting commit 05292945f33bd083b92c1bd85c5ab4239556bc26. It was originally added in https://github.com/dbt-labs/hubcap/pull/222, but the hubcap script + dbt Package Hub couldn't handle packages that contained exclusively pre-releases at the time. The package has a tag representing a final release now, so we can add it back (even though hubcap still has the [original issue](https://github.com/dbt-labs/hubcap/issues/228)).