### PR TITLE
Refactor imports to empower testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ export CONFIG=$(<config.json)
 
 Run:
 ```shell
-python3 hubcap/hubcap.py
+python3 hubcap.py
 ```
 
 ## Run in production mode
@@ -55,7 +55,7 @@ python3 hubcap/hubcap.py
 
 Run:
 ```shell
-python3 hubcap/hubcap.py
+python3 hubcap.py
 ```
 
 ## Testing locally

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,7 +16,7 @@ It is designed to do the following:
 The commands below assume a production application named `dbt-hubcap`. Replace with `dbt-hubcap-staging` for the staging version of the application.
 
 1. Use the [Heroku Scheduler](https://dashboard.heroku.com/apps/dbt-hubcap/scheduler) to set the following cron schedule:
-    - Job: `python3 hubcap/hubcap.py`
+    - Job: `python3 hubcap.py`
     - Schedule: Every hour at :00
     - Dyno size: Hobby / Standard-1X
 1. Configure the `CONFIG` environment variable: [Settings > Config Vars > Reveal Config Vars](https://dashboard.heroku.com/apps/dbt-hubcap/settings)
@@ -58,7 +58,7 @@ git push heroku main:main
 For off-schedule ad hoc executions, run the following from the deploy directory above:
 
 ```shell
-heroku run python3 hubcap/hubcap.py
+heroku run python3 hubcap.py
 ```
 
 #### Explanation

--- a/hubcap.py
+++ b/hubcap.py
@@ -2,12 +2,17 @@ import logging
 
 from pathlib import Path
 
-import helper
-import package
-import release_carrier
+from hubcap import helper
+from hubcap import package
+from hubcap import package_maintainers
+from hubcap import release_carrier
 
-from git_helper import config_token_authorization, repo_default_branch, clone_repo
-from records import IndividualPullRequests, ConsolididatedPullRequest
+from hubcap.git_helper import (
+    config_token_authorization,
+    repo_default_branch,
+    clone_repo,
+)
+from hubcap.records import IndividualPullRequests, ConsolididatedPullRequest
 
 
 # ==
@@ -30,7 +35,7 @@ REMOTE = f"https://github.com/{github_org}/{github_repo}.git"
 PULL_REQUEST_URL = f"https://api.github.com/repos/{github_org}/{github_repo}/pulls"
 git_tmp = "target"
 TMP_DIR = Path(git_tmp).resolve()
-PACKAGE_MAINTAINERS = helper.load_package_maintainers()
+PACKAGE_MAINTAINERS = package_maintainers.load_package_maintainers()
 
 if one_branch_per_repo:
     pr_strategy = IndividualPullRequests()

--- a/hubcap/helper.py
+++ b/hubcap/helper.py
@@ -6,7 +6,6 @@ import logging
 import os
 
 from pathlib import Path
-from records import PackageMaintainer
 
 NOW = int(datetime.datetime.now().timestamp())
 
@@ -20,28 +19,6 @@ logging.basicConfig(
 def build_config():
     """Pull the config env variable which holds github secrets"""
     return json.loads(os.environ["CONFIG"])
-
-
-def load_package_maintainers():
-    """Hub's state determined by packages and their maintainers listed in hub.json"""
-    with open("hub.json", "r") as hub_stream, open(
-        "exclusions.json"
-    ) as excluded_stream:
-        org_pkg_index = json.load(hub_stream)
-        # Mila: we should strive to periodically remove dead packages from hub.json
-        excluded_pkgs_index = json.load(excluded_stream)
-
-    # Remove excluded dictionaries
-    maintainer_index = {
-        org: set(pkgs) - set(excluded_pkgs_index.get(org, []))
-        for org, pkgs in org_pkg_index.items()
-    }
-
-    return [
-        PackageMaintainer(org_name, org_pkgs)
-        for org_name, org_pkgs in maintainer_index.items()
-        if maintainer_index[org_name]
-    ]
 
 
 def build_pkg_version_index(hub_path):

--- a/hubcap/package.py
+++ b/hubcap/package.py
@@ -7,10 +7,9 @@ import yaml
 from git import Repo
 from pathlib import Path
 
-import records
-import version
-
-from git_helper import clone_repo, run_cmd
+from hubcap import records
+from hubcap import version
+from hubcap.git_helper import clone_repo, run_cmd
 
 
 def clone_package_repos(package_maintainer_index, path):

--- a/hubcap/package_maintainers.py
+++ b/hubcap/package_maintainers.py
@@ -1,0 +1,25 @@
+import json
+
+from hubcap.records import PackageMaintainer
+
+
+def load_package_maintainers():
+    """Hub's state determined by packages and their maintainers listed in hub.json"""
+    with open("hub.json", "r") as hub_stream, open(
+        "exclusions.json"
+    ) as excluded_stream:
+        org_pkg_index = json.load(hub_stream)
+        # Mila: we should strive to periodically remove dead packages from hub.json
+        excluded_pkgs_index = json.load(excluded_stream)
+
+    # Remove excluded dictionaries
+    maintainer_index = {
+        org: set(pkgs) - set(excluded_pkgs_index.get(org, []))
+        for org, pkgs in org_pkg_index.items()
+    }
+
+    return [
+        PackageMaintainer(org_name, org_pkgs)
+        for org_name, org_pkgs in maintainer_index.items()
+        if maintainer_index[org_name]
+    ]

--- a/hubcap/records.py
+++ b/hubcap/records.py
@@ -1,19 +1,19 @@
 """Interface for objects useful to processing hub entries"""
 
-import git_helper
 import hashlib
 import json
 import logging
 import os
 import requests
-import helper
 import subprocess
-import version
 
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-import package
+from hubcap import git_helper
+from hubcap import helper
+from hubcap import package
+from hubcap import version
 
 
 class PullRequestStrategy(ABC):

--- a/hubcap/release_carrier.py
+++ b/hubcap/release_carrier.py
@@ -2,10 +2,11 @@
 
 import json
 import requests
-import helper
 
 from git import Repo
 from git.remote import Remote
+
+from hubcap import helper
 
 
 def make_pr(org, repo, head, user_creds, url, pr_strategy, base="main"):


### PR DESCRIPTION
Resolves #235

## Description
After this is merged, files like `tests/test_version_regex.py` with pytest specifications should be able to successfully import any modules/classes/functions from the hubcap project.

This will lower the barrier for creating unit tests for new or existing functionality. Most importantly, it will empower testing for specific bugs that we want to fix!

### Post-merge checklist
- [ ] Update Heroku so that the cron schedule runs `python3 hubcap.py` instead of `python3 hubcap/hubcap.py`
- [ ] Confirm that the script runs successfully at the top of the hour