### PR TITLE
add dbt-duckdb-utils

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -265,6 +265,9 @@
         "dbt-customer-journey-analysis",
         "dbt-events-registry"
     ],
+    "sdebruyn": [
+        "dbt-duckdb-utils"
+    ],
     "sgoley": [
         "dbt-postgres-utils"
     ],


### PR DESCRIPTION
## Description 

Utility package for users of duckdb to map macros from popular dbt packages. I'm using duckdb in a personal project and I'm fixing the ones I bump into.

Link to your package's repository: https://github.com/sdebruyn/dbt-duckdb-utils

## Checklist

### First run experience
- [x] The package includes a README which explains how to get started with the package and customise its behaviour
- [x] The README indicates which data warehouses/platforms are expected to work with this package

### Customisability
- [x] The package uses ref or source, instead of hard-coding table references.

### Dependencies
#### Dependencies on dbt Core
- [x] The package has set a supported `require-dbt-version` range in `dbt_project.yml`. Example: A package which depends on functionality added in dbt Core 1.2 should set its `require-dbt-version` property to `[">=1.2.0", "<2.0.0"]`.

#### Dependencies on other packages defined in packages.yml:
- [x] Dependencies are imported from the dbt Package Hub when available, as opposed to a git installation.
- [x] Dependencies contain the widest possible range of supported versions, to minimise issues in dependency resolution.
- [x] In particular, dependencies are not pinned to a patch version unless there is a known incompatibility.
### Interoperability
- [x] The package does not override dbt Core behaviour in such a way as to impact other dbt resources (models, tests, etc) not provided by the package.
- [x] The package uses the cross-database macros built into dbt Core where available, such as `{{ dbt.except() }}` and `{{ dbt.type_string() }}`.
- [x] The package disambiguates its resource names to avoid clashes with nodes that are likely to already exist in a project. For example, packages should not provide a model simply called `users`.

### Versioning
- [x] (Required): The package's git tags validates against the regex defined in [version.py](/hubcap/version.py)
- [x] The package's version follows the guidance of Semantic Versioning 2.0.0. (Note in particular the recommendation for production-ready packages to be version 1.0.0 or above)
