### PR TITLE
Update exclusions.json

### DIFF
--- a/exclusions.json
+++ b/exclusions.json
@@ -20,9 +20,5 @@
    "beautypie":[
       "dbt-google-analytics-360",
       "dbt-zendesk-support"
-   ],
-   "fivetran":[
-      "dbt_zuora",
-      "dbt_zuora_source"
    ]
 }


### PR DESCRIPTION
We recently released our [dbt_zuora_source](https://github.com/fivetran/dbt_zuora_source) dbt package and I noticed it was not showing up on the dbt hub. It wasn't until just now that I realized it was being excluded for some reason (probably because we hadn't had built it until just now. 

This PR is removing the exclusion list for Fivetran packages as all should be ready for the spotlight on the hub 🕺 