### PR TITLE
Rename dbtvault to AutomateDV

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -3,7 +3,7 @@
         "dbt-synapse-statistics"
     ],
     "Datavault-UK": [
-        "dbtvault"
+        "automate-dv"
     ],
     "Datomni": [
         "profitwell_metrics",


### PR DESCRIPTION
Update dbtvault to AutomateDV for rebrand
No other changes otherwise

Corresponding hub.getdbt.com PR: https://github.com/dbt-labs/hub.getdbt.com/pull/2470