### PR TITLE
Revert "Rename dbtvault to AutomateDV"

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -6,7 +6,7 @@
         "dbt-incremental-stream"
     ],
     "Datavault-UK": [
-        "automate-dv"
+        "dbtvault"
     ],
     "Datomni": [
         "profitwell_metrics",


### PR DESCRIPTION
Reverts dbt-labs/hubcap#258

@DVAlexHiggs If you want to change the name of the package, you'll actually want to change [this](https://github.com/Datavault-UK/dbtvault/blob/4ce2cfbd8c17fb33ea95ae65b52c193a73ec45e5/dbt_project.yml#L1) line.

The line you changed in hub.json is actually the name of the GitHub repo that it will look for.

Here's a good example of a case where the repo name and the package name are different:
- `hub.json` points to the [GitHub organization + repo name](https://github.com/dbt-labs/hubcap/pull/257/files)
- [The package page](https://hub.getdbt.com/arnon7/incr_stream/latest/) on hub.getdbt.com uses the [package name in `dbt_project.yml`](https://github.com/arnoN7/dbt-incremental-stream/blob/88c2631c03c6df1741819c17c382a68948e8ac42/dbt_project.yml#L1)

Since neither your package name nor GitHub repo changed, I'm going to revert this for now.

Sorry I didn't check this earlier!