### PR TITLE
Update hub.json to use sutrolabs organization

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -70,9 +70,6 @@
         "dbt-date",
         "dbt-expectations"
     ],
-    "census": [
-        "dbt_census_utils"
-    ],
     "cerebriumai": [
         "airbyte_dbt_intercom",
         "airbyte_dbt_facebook_ads",
@@ -338,6 +335,9 @@
     ],
     "starburstdata": [
         "dbt-trino-utils"
+    ],
+    "sutrolabs": [
+        "dbt_census_utils"
     ],
     "techindicium": [
         "dbt-metalog"


### PR DESCRIPTION
I previously put our package under 'census', but the github org is 'sutrolabs'.  The main PR was already approved.