### PR TITLE
Add `yu-iskw/dbt-ops`

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -383,6 +383,7 @@
     "yu-iskw": [
         "dbt-airflow-macros",
         "dbt-unittest",
-        "dbt-gcp-billing"
+        "dbt-gcp-billing",
+        "dbt-ops"
     ]
 }


### PR DESCRIPTION
## Description 

I have implemented a new dbt Package to help maintaining a dbt project. For instance, currently, it provides the `dbt_ops.find_unreferenced_sources` macro which enables us to find sources unreferenced by any dbt models, snapshots and exposures.

Link to your package's repository:  https://github.com/yu-iskw/dbt-ops

## Checklist
_This checklist is a cut down version of the [best practices](../blob/main/package-best-practices.md) that we have identified as the package hub has grown. Although meeting these checklist items is not a prerequisite to being added to the Hub, we have found that packages which don't conform provide a worse user experience._

### First run experience
- [x] The package includes a README which explains how to get started with the package and customise its behaviour
- [x] The README indicates which data warehouses/platforms are expected to work with this package

### Customisability
- [ ] The package uses ref or source, instead of hard-coding table references.

### Dependencies
#### Dependencies on dbt Core
- [x] The package has set a supported `require-dbt-version` range in `dbt_project.yml`. Example: A package which depends on functionality added in dbt Core 1.2 should set its `require-dbt-version` property to `[">=1.2.0", "<2.0.0"]`.
#### Dependencies on other packages defined in packages.yml:
- [ ] Dependencies are imported from the dbt Package Hub when available, as opposed to a git installation.
- [ ] Dependencies contain the widest possible range of supported versions, to minimise issues in dependency resolution.
- [ ] In particular, dependencies are not pinned to a patch version unless there is a known incompatibility.
### Interoperability
- [x] The package does not override dbt Core behaviour in such a way as to impact other dbt resources (models, tests, etc) not provided by the package.
- [ ] The package uses the cross-database macros built into dbt Core where available, such as `{{ dbt.except() }}` and `{{ dbt.type_string() }}`.
- [x] The package disambiguates its resource names to avoid clashes with nodes that are likely to already exist in a project. For example, packages should not provide a model simply called `users`.

### Versioning
- [x] (Required): The package's git tags validates against the regex defined in [version.py](/hubcap/version.py)
- [x] The package's version follows the guidance of Semantic Versioning 2.0.0. (Note in particular the recommendation for production-ready packages to be version 1.0.0 or above)
