### PR TITLE
adding gmdata-co to hub.json

### DIFF
--- a/hub.json
+++ b/hub.json
@@ -290,6 +290,9 @@
     "gitlabhq": [
         "snowflake_spend"
     ],
+    "gmdata-co": [
+        "dbt-portable-google-sheets"
+    ],
     "google": [
         "fhir-dbt-utils",
         "fhir-dbt-analytics"


### PR DESCRIPTION
## Description 

_Tell us about your new package!_

This package is the first in a series of packages to come that aim at making connectors from Portable.io easier to use. 
This packages contains a single macro that will unnest the json payload from Portable's Google Sheets connector.
It transforms the single variant column called "ROWDATA" back to the original columns as they existed in the Google Sheet.

Since this is my first time doing this, I'm not 100% clear on how this all works.  I guessed the naming convention in hub.json is:
org-name: [repo-name]... but that was not clear to me from the docs.  I guess somehow it automatically will link to my repo based on that?

I have questions about versioning.  Can you hit me up on Slack so I can ask?  I'm Jeff Skoldberg on dbt Slack.
Can I update the readme without updating the version?  Example, I will need to update the install instructions in the readme if this is going live.

Link to your package's repository: 
https://github.com/gmdata-co/dbt-portable-google-sheets

## Checklist
_This checklist is a cut down version of the [best practices](../blob/main/package-best-practices.md) that we have identified as the package hub has grown. Although meeting these checklist items is not a prerequisite to being added to the Hub, we have found that packages which don't conform provide a worse user experience._

### First run experience
- [x] The package includes a README which explains how to get started with the package and customise its behaviour
- [x] The README indicates which data warehouses/platforms are expected to work with this package

### Customisability
- [x] The package uses ref or source, instead of hard-coding table references.
#### Packages for data transformation (delete if not relevant):
- [x] provide a mechanism (such as variables) to customise the location of source tables.
- [x] do not assume database/schema names in sources.

### Dependencies
#### Dependencies on dbt Core
- [x] The package has set a supported `require-dbt-version` range in `dbt_project.yml`. Example: A package which depends on functionality added in dbt Core 1.2 should set its `require-dbt-version` property to `[">=1.2.0", "<2.0.0"]`.
#### Dependencies on other packages defined in packages.yml:
- [x] Dependencies are imported from the dbt Package Hub when available, as opposed to a git installation.
- [x] Dependencies contain the widest possible range of supported versions, to minimise issues in dependency resolution.
- [x] In particular, dependencies are not pinned to a patch version unless there is a known incompatibility.
### Interoperability
- [x] The package does not override dbt Core behaviour in such a way as to impact other dbt resources (models, tests, etc) not provided by the package.
- [ ] The package uses the cross-database macros built into dbt Core where available, such as `{{ dbt.except() }}` and `{{ dbt.type_string() }}`.
- [x] The package disambiguates its resource names to avoid clashes with nodes that are likely to already exist in a project. For example, packages should not provide a model simply called `users`.

### Versioning
- [x] (Required): The package's git tags validates against the regex defined in [version.py](/hubcap/version.py)
- [x] The package's version follows the guidance of Semantic Versioning 2.0.0. (Note in particular the recommendation for production-ready packages to be version 1.0.0 or above)
