### PR TITLE
Add licence requirement to best practices doc

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Link to your package's repository:
 _This checklist is a cut down version of the [best practices](../blob/main/package-best-practices.md) that we have identified as the package hub has grown. Although meeting these checklist items is not a prerequisite to being added to the Hub, we have found that packages which don't conform provide a worse user experience._
 
 ### First run experience
+- [ ] (Required): The package includes a [licence file detectable by GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository), such as the Apache 2.0 or MIT licence.
 - [ ] The package includes a README which explains how to get started with the package and customise its behaviour
 - [ ] The README indicates which data warehouses/platforms are expected to work with this package
 

--- a/package-best-practices.md
+++ b/package-best-practices.md
@@ -13,6 +13,7 @@ To avoid ambiguity, the bullets below are pretty formal, but we are a friendly b
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
 ### First run experience
+- Packages MUST include a [licence file detectable by GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository). We strongly encourage an open source licence such as Apache 2.0 or MIT.
 - Packages SHOULD contain a README file which explains how to get started with the package and customise its behaviour.
 - The documentation SHOULD indicate which data warehouses are expected to work with this package.
 


### PR DESCRIPTION
## Description 

Update to the best practices doc and PR checklist to ensure all packages have a licence explicitly specified.